### PR TITLE
Generate secondary UV set for lightmapping by default.

### DIFF
--- a/SimplestMeshBaker/Editor/BonesBaker.cs
+++ b/SimplestMeshBaker/Editor/BonesBaker.cs
@@ -76,6 +76,10 @@ namespace SimplestMeshBaker
                 }
                 //and remove it
                 Undo.DestroyObjectImmediate(skinnedMeshRenderer);
+
+                // Generate UV2 for Lightmapping
+                Unwrapping.GenerateSecondaryUVSet(newMesh);
+
                 //add and setup meshFilter and meshRenderer
                 MeshFilter meshFilter = Undo.AddComponent<MeshFilter>(gameObject);
                 meshFilter.mesh = newMesh;


### PR DESCRIPTION
When baking bones, automatically generate a set of lightmap UVs for baked skinned meshes, since there won't be a way to do that in Unity through the UI anymore ("Generate Lightmap UVs" in the import settings for rigged models has no effect).
BakeMesh also uses BakeBones, so this should work for skinned meshes invoked in BakeMesh too.